### PR TITLE
Fix malformatted activity removal confirmation dialog text

### DIFF
--- a/feature-activities/src/androidTest/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesTests.kt
+++ b/feature-activities/src/androidTest/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesTests.kt
@@ -2,6 +2,7 @@ package com.jeanbarrossilva.ongoing.feature.activities
 
 import android.content.Context
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasTextExactly
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -19,6 +20,7 @@ import com.jeanbarrossilva.ongoing.context.registry.extensions.register
 import com.jeanbarrossilva.ongoing.core.registry.observation.Observation
 import com.jeanbarrossilva.ongoing.core.session.inmemory.InMemoryUserRepository
 import com.jeanbarrossilva.ongoing.feature.activities.component.REMOVAL_CONFIRMATION_DIALOG_CONFIRMATION_BUTTON_TAG
+import com.jeanbarrossilva.ongoing.feature.activities.component.REMOVAL_CONFIRMATION_DIALOG_TEXT_TAG
 import com.jeanbarrossilva.ongoing.feature.activities.component.activitycard.ActivityCard
 import com.jeanbarrossilva.ongoing.feature.activities.component.scaffold.topappbar.TOP_APP_BAR_SELECTION_ACTIONS_REMOVE_TAG
 import com.jeanbarrossilva.ongoing.feature.activities.extensions.hasTestTagPrefixedWith
@@ -36,12 +38,16 @@ import org.junit.Test
 internal class ActivitiesTests {
     private lateinit var fetcher: ContextualActivitiesFetcher
 
+    private val activity
+        get() = ContextualActivity.sample
     private val activityCard
         get() = composeRule.onNode(hasTestTagPrefixedWith(ActivityCard.TAG))
     private val activityRegistry
         get() = platformRegistryRule.activityRegistry
     private val context
         get() = ApplicationProvider.getApplicationContext<Context>()
+    private val removeButton
+        get() = composeRule.onNodeWithTag(TOP_APP_BAR_SELECTION_ACTIONS_REMOVE_TAG)
     private val session
         get() = platformRegistryRule.session
 
@@ -65,6 +71,22 @@ internal class ActivitiesTests {
             context.resources.getQuantityString(R.plurals.feature_activities_selection, 1, 1)
         )
         assertTrue(activityCard.fetchSemanticsNode().config[SemanticsProperties.Selected])
+    }
+
+    @Test
+    fun showConfirmationDialogWhenRemovingAnActivity() {
+        registerActivity()
+        longClickFirstActivity()
+        removeButton.performClick()
+        composeRule
+            .onNodeWithTag(REMOVAL_CONFIRMATION_DIALOG_TEXT_TAG)
+            .assertTextEquals(
+                context.resources.getQuantityString(
+                    R.plurals.feature_activities_removal_confirmation,
+                    1,
+                    activity.name
+                )
+            )
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -107,7 +129,7 @@ internal class ActivitiesTests {
 
     private fun removeFirstActivity() {
         longClickFirstActivity()
-        composeRule.onNodeWithTag(TOP_APP_BAR_SELECTION_ACTIONS_REMOVE_TAG).performClick()
+        removeButton.performClick()
         composeRule.onNodeWithTag(REMOVAL_CONFIRMATION_DIALOG_CONFIRMATION_BUTTON_TAG)
             .performClick()
     }

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/RemovalConfirmationDialog.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/RemovalConfirmationDialog.kt
@@ -13,6 +13,7 @@ import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesSelection
 import com.jeanbarrossilva.ongoing.feature.activities.R
 
 internal const val REMOVAL_CONFIRMATION_DIALOG_TAG = "removal_confirmation_dialog"
+internal const val REMOVAL_CONFIRMATION_DIALOG_TEXT_TAG = "removal_confirmation_dialog_text"
 internal const val REMOVAL_CONFIRMATION_DIALOG_CONFIRMATION_BUTTON_TAG =
     "removal_confirmation_dialog_confirmation_button"
 
@@ -24,6 +25,10 @@ internal fun RemovalConfirmationDialog(
     onConfirmationRequest: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val selectionCount = selection.selected.size
+    val textFormatArg =
+        if (selectionCount == 1) selection.selected.single().name else selectionCount
+
     AlertDialog(
         onDismissalRequest,
         confirmButton = {
@@ -44,9 +49,10 @@ internal fun RemovalConfirmationDialog(
             Text(
                 pluralStringResource(
                     R.plurals.feature_activities_removal_confirmation,
-                    selection.selected.size,
-                    selection.selected.size
-                )
+                    selectionCount,
+                    textFormatArg
+                ),
+                Modifier.testTag(REMOVAL_CONFIRMATION_DIALOG_TEXT_TAG)
             )
         }
     )


### PR DESCRIPTION
When removing a single activity, the confirmation dialog text displayed "1" (the amount of activities selected) instead of the name of the activity that was being removed.

<div>
    <img width="256" src="https://user-images.githubusercontent.com/38408390/208707273-b7b1f56a-8e96-4fc6-bdb9-30541058d960.png" />
    <img width="256" src="https://user-images.githubusercontent.com/38408390/208707323-e8d56313-08a6-45ef-9a78-eae03d784d26.png" />
</div>