### PR TITLE
Add `ActivitiesGateway`

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/ongoing/app/boundary/DefaultActivitiesBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/ongoing/app/boundary/DefaultActivitiesBoundary.kt
@@ -1,7 +1,11 @@
 package com.jeanbarrossilva.ongoing.app.boundary
 
 import android.content.Context
-import com.jeanbarrossilva.ongoing.context.user.ContextualUser
+import com.jeanbarrossilva.ongoing.context.user.extensions.toContextualUser
+import com.jeanbarrossilva.ongoing.core.session.Session
+import com.jeanbarrossilva.ongoing.core.session.SessionManager
+import com.jeanbarrossilva.ongoing.core.session.extensions.session
+import com.jeanbarrossilva.ongoing.core.user.UserRepository
 import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesBoundary
 import com.jeanbarrossilva.ongoing.feature.activitydetails.ActivityDetailsActivity
 import com.jeanbarrossilva.ongoing.feature.activityediting.ActivityEditingActivity
@@ -9,14 +13,26 @@ import com.jeanbarrossilva.ongoing.feature.activityediting.ActivityEditingMode
 import com.jeanbarrossilva.ongoing.feature.authentication.AuthenticationActivity
 import com.jeanbarrossilva.ongoing.feature.settings.SettingsActivity
 import com.jeanbarrossilva.ongoing.platform.extensions.startActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
-internal class DefaultActivitiesBoundary: ActivitiesBoundary {
+internal class DefaultActivitiesBoundary(
+    private val sessionManager: SessionManager,
+    private val userRepository: UserRepository
+): ActivitiesBoundary {
     override fun navigateToAuthentication(context: Context) {
         context.startActivity<AuthenticationActivity>()
     }
 
-    override fun navigateToSettings(context: Context, user: ContextualUser) {
-        SettingsActivity.start(context, user)
+    override fun navigateToSettings(context: Context, coroutineScope: CoroutineScope) {
+        coroutineScope.launch {
+            sessionManager
+                .session<Session.SignedIn>()
+                ?.userId
+                ?.let { userRepository.getUserById(it) }
+                ?.toContextualUser()
+                ?.let { SettingsActivity.start(context, it) }
+        }
     }
 
     override fun navigateToActivityDetails(context: Context, activityId: String) {

--- a/app/src/main/java/com/jeanbarrossilva/ongoing/app/extensions/KoinJavaComponentExtensions.kt
+++ b/app/src/main/java/com/jeanbarrossilva/ongoing/app/extensions/KoinJavaComponentExtensions.kt
@@ -1,0 +1,8 @@
+package com.jeanbarrossilva.ongoing.app.extensions
+
+import org.koin.java.KoinJavaComponent
+
+/** Gets the injected [T] value. **/
+internal inline fun <reified T> get(): T {
+    return KoinJavaComponent.get(T::class.java)
+}

--- a/app/src/main/java/com/jeanbarrossilva/ongoing/app/module/BoundaryModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/ongoing/app/module/BoundaryModule.kt
@@ -8,5 +8,7 @@ import org.koin.dsl.module
 
 internal val boundaryModule = module {
     single<ActivityDetailsBoundary> { DefaultActivityDetailsBoundary() }
-    single<ActivitiesBoundary> { DefaultActivitiesBoundary() }
+    single<ActivitiesBoundary> {
+        DefaultActivitiesBoundary(sessionManager = get(), userRepository = get())
+    }
 }

--- a/app/src/shared/java/com/jeanbarrossilva/ongoing/app/OngoingApplication.kt
+++ b/app/src/shared/java/com/jeanbarrossilva/ongoing/app/OngoingApplication.kt
@@ -6,6 +6,7 @@ import com.jeanbarrossilva.ongoing.app.module.coreModule
 import com.jeanbarrossilva.ongoing.app.module.feature.contextualRegistryModule
 import com.jeanbarrossilva.ongoing.app.module.feature.extensionsModule
 import com.jeanbarrossilva.ongoing.app.module.feature.settingsModule
+import com.jeanbarrossilva.ongoing.feature.activities.activitiesModule
 import com.jeanbarrossilva.ongoing.feature.activitydetails.activityDetailsModule
 import com.jeanbarrossilva.ongoing.feature.authentication.authenticationModule
 import org.koin.android.ext.koin.androidContext
@@ -27,7 +28,7 @@ open class OngoingApplication: Application() {
         startKoin {
             androidContext(this@OngoingApplication)
             modules(coreModule, boundaryModule)
-            modules(authenticationModule, activityDetailsModule, settingsModule)
+            modules(authenticationModule, activitiesModule, activityDetailsModule, settingsModule)
             modules(extensionsModule, contextualRegistryModule)
         }
     }

--- a/context-user/src/main/java/com/jeanbarrossilva/ongoing/context/user/component/Avatar.kt
+++ b/context-user/src/main/java/com/jeanbarrossilva/ongoing/context/user/component/Avatar.kt
@@ -20,9 +20,9 @@ object Avatar {
 }
 
 @Composable
-fun Avatar(user: ContextualUser?, modifier: Modifier = Modifier) {
+fun Avatar(url: String?, modifier: Modifier = Modifier) {
     AsyncImage(
-        user?.avatarUrl,
+        url,
         contentDescription = stringResource(R.string.context_user_avatar_content_description),
         modifier
             .clip(shape)
@@ -35,6 +35,6 @@ fun Avatar(user: ContextualUser?, modifier: Modifier = Modifier) {
 @Preview
 private fun AvatarPreview() {
     OngoingTheme {
-        Avatar(ContextualUser.sample)
+        Avatar(ContextualUser.sample.avatarUrl)
     }
 }

--- a/feature-activities/build.gradle
+++ b/feature-activities/build.gradle
@@ -45,14 +45,14 @@ dependencies {
     implementation project(':context-user')
     implementation project(':core-registry')
     implementation project(':core-session')
+    implementation project(':core-session-in-memory')
     implementation project(':core-user')
+    implementation project(':core-user-in-memory')
     implementation project(':platform-design-system')
     implementation project(':platform-loadable')
     implementation libraries.compose.material_icons_extended
     implementation libraries.navigation.runtime
 
-    testImplementation project(':core-session-in-memory')
-    testImplementation project(':core-user-in-memory')
     testImplementation libraries.kotlinx.coroutines.test
     testImplementation libraries.test.ext.junit
     testImplementation libraries.turbine

--- a/feature-activities/src/androidTest/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesTests.kt
+++ b/feature-activities/src/androidTest/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesTests.kt
@@ -24,6 +24,7 @@ import com.jeanbarrossilva.ongoing.feature.activities.component.REMOVAL_CONFIRMA
 import com.jeanbarrossilva.ongoing.feature.activities.component.activitycard.ActivityCard
 import com.jeanbarrossilva.ongoing.feature.activities.component.scaffold.topappbar.TOP_APP_BAR_SELECTION_ACTIONS_REMOVE_TAG
 import com.jeanbarrossilva.ongoing.feature.activities.extensions.hasTestTagPrefixedWith
+import com.jeanbarrossilva.ongoing.feature.activities.inmemory.InMemoryActivitiesGateway
 import com.jeanbarrossilva.ongoing.platform.designsystem.component.scaffold.topappbar.TOP_APP_BAR_TAG
 import com.jeanbarrossilva.ongoing.platform.loadable.extensions.unwrap
 import com.jeanbarrossilva.ongoing.platform.registry.test.PlatformRegistryTestRule
@@ -115,7 +116,8 @@ internal class ActivitiesTests {
     }
 
     private fun setContent() {
-        val viewModel = ActivitiesViewModel(sessionManager, userRepository, fetcher)
+        val gateway = InMemoryActivitiesGateway(sessionManager, fetcher)
+        val viewModel = ActivitiesViewModel(gateway)
         composeRule.setContent {
             Activities(viewModel, ActivitiesBoundary.empty, activityRegistry, Observation.empty)
         }

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesActivity.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesActivity.kt
@@ -2,19 +2,19 @@ package com.jeanbarrossilva.ongoing.feature.activities
 
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
-import com.jeanbarrossilva.ongoing.context.registry.domain.activity.fetcher.ContextualActivitiesFetcher
-import com.jeanbarrossilva.ongoing.core.session.SessionManager
-import com.jeanbarrossilva.ongoing.core.user.UserRepository
 import com.jeanbarrossilva.ongoing.platform.designsystem.core.composable.ComposableActivity
 import org.koin.android.ext.android.inject
 
 class ActivitiesActivity internal constructor(): ComposableActivity() {
-    private val sessionManager by inject<SessionManager>()
-    private val userRepository by inject<UserRepository>()
-    private val fetcher by inject<ContextualActivitiesFetcher>()
+    private val gateway by inject<ActivitiesGateway>()
     private val boundary by inject<ActivitiesBoundary>()
     private val viewModel by viewModels<ActivitiesViewModel> {
-        ActivitiesViewModel.createFactory(sessionManager, userRepository, fetcher)
+        ActivitiesViewModel.createFactory(gateway)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.fetch()
     }
 
     @Composable

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesBoundary.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesBoundary.kt
@@ -1,12 +1,12 @@
 package com.jeanbarrossilva.ongoing.feature.activities
 
 import android.content.Context
-import com.jeanbarrossilva.ongoing.context.user.ContextualUser
+import kotlinx.coroutines.CoroutineScope
 
 interface ActivitiesBoundary {
     fun navigateToAuthentication(context: Context)
 
-    fun navigateToSettings(context: Context, user: ContextualUser)
+    fun navigateToSettings(context: Context, coroutineScope: CoroutineScope)
 
     fun navigateToActivityDetails(context: Context, activityId: String)
 
@@ -17,7 +17,7 @@ interface ActivitiesBoundary {
             override fun navigateToAuthentication(context: Context) {
             }
 
-            override fun navigateToSettings(context: Context, user: ContextualUser) {
+            override fun navigateToSettings(context: Context, coroutineScope: CoroutineScope) {
             }
 
             override fun navigateToActivityDetails(context: Context, activityId: String) {

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesGateway.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesGateway.kt
@@ -1,0 +1,16 @@
+package com.jeanbarrossilva.ongoing.feature.activities
+
+import com.jeanbarrossilva.ongoing.context.registry.domain.activity.ContextualActivity
+import com.jeanbarrossilva.ongoing.platform.loadable.Loadable
+import com.jeanbarrossilva.ongoing.platform.loadable.type.SerializableList
+import kotlinx.coroutines.flow.Flow
+
+interface ActivitiesGateway {
+    suspend fun getCurrentOwner(): Flow<Loadable<ActivitiesOwner?>>
+
+    suspend fun getActivities(): Flow<Loadable<SerializableList<ContextualActivity>>>
+
+    suspend fun fetch()
+
+    suspend fun unregister(activityIds: List<String>)
+}

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesModule.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesModule.kt
@@ -1,0 +1,10 @@
+package com.jeanbarrossilva.ongoing.feature.activities
+
+import com.jeanbarrossilva.ongoing.feature.activities.inmemory.InMemoryActivitiesGateway
+import org.koin.dsl.module
+
+val activitiesModule = module {
+    single<ActivitiesGateway> {
+        InMemoryActivitiesGateway(sessionManager = get(), userRepository = get(), fetcher = get())
+    }
+}

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesOwner.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/ActivitiesOwner.kt
@@ -1,0 +1,11 @@
+package com.jeanbarrossilva.ongoing.feature.activities
+
+import com.jeanbarrossilva.ongoing.context.registry.extensions.toActivitiesOwner
+import com.jeanbarrossilva.ongoing.context.user.ContextualUser
+import java.io.Serializable
+
+data class ActivitiesOwner(val id: String, val avatarUrl: String?): Serializable {
+    companion object {
+        val sample = ContextualUser.sample.toActivitiesOwner()
+    }
+}

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/OwnerAvatar.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/OwnerAvatar.kt
@@ -14,16 +14,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.jeanbarrossilva.ongoing.context.user.ContextualUser
 import com.jeanbarrossilva.ongoing.context.user.component.Avatar
+import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesOwner
 import com.jeanbarrossilva.ongoing.feature.activities.R
 import com.jeanbarrossilva.ongoing.platform.designsystem.theme.OngoingTheme
 
 @Composable
-internal fun AvatarIcon(user: ContextualUser?, onClick: () -> Unit, modifier: Modifier = Modifier) {
-    user?.let {
+internal fun OwnerAvatar(
+    owner: ActivitiesOwner?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    owner?.let {
         Avatar(
-            user,
+            it.avatarUrl,
             modifier
                 .clip(Avatar.shape)
                 .clickable(onClick = onClick)
@@ -45,7 +49,7 @@ internal fun AvatarIcon(user: ContextualUser?, onClick: () -> Unit, modifier: Mo
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun ExistentUserAvatarIconPreview() {
     OngoingTheme {
-        AvatarIcon(ContextualUser.sample, onClick = { })
+        OwnerAvatar(ActivitiesOwner.sample, onClick = { })
     }
 }
 
@@ -54,6 +58,6 @@ private fun ExistentUserAvatarIconPreview() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun NonexistentUserAvatarIconPreview() {
     OngoingTheme {
-        AvatarIcon(user = null, onClick = { })
+        OwnerAvatar(owner = null, onClick = { })
     }
 }

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/activitycard/component/TertiaryInfo.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/activitycard/component/TertiaryInfo.kt
@@ -24,7 +24,7 @@ internal object TertiaryInfo {
 @Composable
 internal fun TertiaryInfo(activity: Loadable<ContextualActivity>, modifier: Modifier = Modifier) {
     Row(modifier, Arrangement.spacedBy(Size.Spacing.s), Alignment.CenterVertically) {
-        Avatar(activity.ifLoaded(ContextualActivity::owner), Modifier.size(Height))
+        Avatar(activity.ifLoaded { owner?.avatarUrl }, Modifier.size(Height))
         StatusIndicator(activity.ifLoaded(ContextualActivity::status))
     }
 }

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/scaffold/topappbar/TopAppBar.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/scaffold/topappbar/TopAppBar.kt
@@ -8,17 +8,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.jeanbarrossilva.ongoing.context.registry.domain.activity.ContextualActivity
-import com.jeanbarrossilva.ongoing.context.user.ContextualUser
+import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesOwner
 import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesSelection
 import com.jeanbarrossilva.ongoing.feature.activities.R
 import com.jeanbarrossilva.ongoing.feature.activities.extensions.ifOn
 import com.jeanbarrossilva.ongoing.platform.designsystem.component.scaffold.topappbar.TopAppBar
 import com.jeanbarrossilva.ongoing.platform.designsystem.component.scaffold.topappbar.TopAppBarStyle
 import com.jeanbarrossilva.ongoing.platform.designsystem.theme.OngoingTheme
+import com.jeanbarrossilva.ongoing.platform.loadable.Loadable
 
 @Composable
 internal fun TopAppBar(
-    user: ContextualUser?,
+    owner: Loadable<ActivitiesOwner?>,
     selection: ActivitiesSelection,
     onSettingsRequest: () -> Unit,
     onUnregistrationRequest: (activities: List<ContextualActivity>) -> Unit,
@@ -38,7 +39,7 @@ internal fun TopAppBar(
         when (selection) {
             is ActivitiesSelection.On ->
                 TopAppBarSelectionActions(selection, onUnregistrationRequest)
-            is ActivitiesSelection.Off -> TopAppBarDefaultActions(user, onSettingsRequest)
+            is ActivitiesSelection.Off -> TopAppBarDefaultActions(owner, onSettingsRequest)
         }
     }
 }
@@ -49,7 +50,7 @@ internal fun TopAppBar(
 private fun TopAppBarPreview() {
     OngoingTheme {
         TopAppBar(
-            user = null,
+            owner = Loadable.Loaded(null),
             ActivitiesSelection.Off,
             onSettingsRequest = { },
             onUnregistrationRequest = { }

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/scaffold/topappbar/TopAppBarDefaultActions.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/component/scaffold/topappbar/TopAppBarDefaultActions.kt
@@ -2,14 +2,18 @@ package com.jeanbarrossilva.ongoing.feature.activities.component.scaffold.topapp
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
-import com.jeanbarrossilva.ongoing.context.user.ContextualUser
-import com.jeanbarrossilva.ongoing.feature.activities.component.AvatarIcon
+import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesOwner
+import com.jeanbarrossilva.ongoing.feature.activities.component.OwnerAvatar
+import com.jeanbarrossilva.ongoing.platform.loadable.Loadable
+import com.jeanbarrossilva.ongoing.platform.loadable.extensions.ifLoaded
 
 @Suppress("UnusedReceiverParameter")
 @Composable
 internal fun RowScope.TopAppBarDefaultActions(
-    user: ContextualUser?,
+    owner: Loadable<ActivitiesOwner?>,
     onSettingsRequest: () -> Unit
 ) {
-    AvatarIcon(user, onClick = onSettingsRequest)
+    owner.ifLoaded {
+        OwnerAvatar(this, onClick = onSettingsRequest)
+    }
 }

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/extensions/ContextualUserExtensions.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/extensions/ContextualUserExtensions.kt
@@ -1,0 +1,9 @@
+package com.jeanbarrossilva.ongoing.context.registry.extensions
+
+import com.jeanbarrossilva.ongoing.context.user.ContextualUser
+import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesOwner
+
+/** Converts the given [ContextualUser] into an [ActivitiesOwner]. **/
+internal fun ContextualUser.toActivitiesOwner(): ActivitiesOwner {
+    return ActivitiesOwner(id, avatarUrl)
+}

--- a/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/inmemory/InMemoryActivitiesGateway.kt
+++ b/feature-activities/src/main/java/com/jeanbarrossilva/ongoing/feature/activities/inmemory/InMemoryActivitiesGateway.kt
@@ -1,0 +1,62 @@
+package com.jeanbarrossilva.ongoing.feature.activities.inmemory
+
+import com.jeanbarrossilva.ongoing.context.registry.domain.activity.ContextualActivity
+import com.jeanbarrossilva.ongoing.context.registry.domain.activity.fetcher.ContextualActivitiesFetcher
+import com.jeanbarrossilva.ongoing.context.registry.extensions.getActivities
+import com.jeanbarrossilva.ongoing.context.registry.extensions.toActivitiesOwner
+import com.jeanbarrossilva.ongoing.context.registry.extensions.unregister
+import com.jeanbarrossilva.ongoing.context.user.extensions.toContextualUser
+import com.jeanbarrossilva.ongoing.core.session.OnSessionChangeListener
+import com.jeanbarrossilva.ongoing.core.session.Session
+import com.jeanbarrossilva.ongoing.core.session.SessionManager
+import com.jeanbarrossilva.ongoing.core.user.UserRepository
+import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesGateway
+import com.jeanbarrossilva.ongoing.feature.activities.ActivitiesOwner
+import com.jeanbarrossilva.ongoing.platform.loadable.Loadable
+import com.jeanbarrossilva.ongoing.platform.loadable.extensions.loadableChannelFlow
+import com.jeanbarrossilva.ongoing.platform.loadable.extensions.send
+import com.jeanbarrossilva.ongoing.platform.loadable.type.SerializableList
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+
+internal class InMemoryActivitiesGateway(
+    private val sessionManager: SessionManager,
+    private val userRepository: UserRepository,
+    private val fetcher: ContextualActivitiesFetcher
+): ActivitiesGateway {
+    override suspend fun getCurrentOwner(): Flow<Loadable<ActivitiesOwner?>> {
+        return loadableChannelFlow {
+            val listener = OnSessionChangeListener {
+                val owner = when (it) {
+                    is Session.SignedOut -> null
+                    is Session.SignedIn -> userRepository
+                        .getUserById(it.userId)
+                        ?.toContextualUser()
+                        ?.toActivitiesOwner()
+                }
+                send(owner)
+                fetch()
+            }
+            listener.onSessionChange(sessionManager.session())
+            sessionManager.attach(listener)
+            awaitClose { sessionManager.detach(listener) }
+        }
+    }
+
+    override suspend fun getActivities(): Flow<Loadable<SerializableList<ContextualActivity>>> {
+        return loadableChannelFlow {
+            fetcher.getActivities().collect {
+                send(it)
+            }
+        }
+    }
+
+    override suspend fun fetch() {
+        fetcher.fetch()
+    }
+
+    override suspend fun unregister(activityIds: List<String>) {
+        activityIds.forEach { fetcher.unregister(it) }
+        fetch()
+    }
+}

--- a/feature-settings/src/main/java/com/jeanbarrossilva/ongoing/feature/settings/component/account/AccountSetting.kt
+++ b/feature-settings/src/main/java/com/jeanbarrossilva/ongoing/feature/settings/component/account/AccountSetting.kt
@@ -41,7 +41,7 @@ internal fun AccountSetting(
     ) {
         SettingsMenuLink(
             title = { AccountSettingNameAndEmail(user, Modifier.offset(x = Size.Spacing.xl)) },
-            icon = { Avatar(user, Modifier.size(42.dp)) },
+            icon = { Avatar(user.avatarUrl, Modifier.size(42.dp)) },
             action = {
                 IconButton(
                     onClick = onSignOutRequest,

--- a/platform-loadable/src/main/java/com/jeanbarrossilva/ongoing/platform/loadable/extensions/ProducerScopeExtensions.kt
+++ b/platform-loadable/src/main/java/com/jeanbarrossilva/ongoing/platform/loadable/extensions/ProducerScopeExtensions.kt
@@ -1,0 +1,14 @@
+package com.jeanbarrossilva.ongoing.platform.loadable.extensions
+
+import com.jeanbarrossilva.ongoing.platform.loadable.Loadable
+import kotlinx.coroutines.channels.ProducerScope
+import java.io.Serializable
+
+/**
+ * Sends the given [element] as a [Loadable.Loaded].
+ *
+ * @param element Element to be sent.
+ **/
+suspend fun <T: Serializable?> ProducerScope<Loadable<T>>.send(element: T) {
+    send(Loadable.Loaded(element))
+}


### PR DESCRIPTION
In order to be prepared to consume data from an actual external API, I'll create a gateway for each of the feature modules that'll only serve the data they really need access to; it's supposed to be a BFF-like interface.

This time, I'm adding the `ActivitiesGateway`.